### PR TITLE
fix: set correct port in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       context: packages/api
     container_name: witty-bufficorns-api
     ports:
-      - $SERVER_PORT:3000
+      - $SERVER_PORT:4000
     links:
       - database
     depends_on:


### PR DESCRIPTION
For example, 80:4000 means that host port 80 will map to container port 4000

There was nothing running in port 3000, so set to 4000.